### PR TITLE
Fix get_current_tenant TypeError

### DIFF
--- a/easy_tenants/utils.py
+++ b/easy_tenants/utils.py
@@ -14,7 +14,7 @@ def get_tenant_model():
 
 
 def get_current_tenant():
-    state = getattr(state_local, "state", None)
+    state = get_state()
 
     if state["enabled"] and state["tenant"] is None:
         raise TenantError("Tenant is required in context.")


### PR DESCRIPTION
If get_current_tenant is called before the state is set Django will throw TypeError, as opposed to TenantError

```
class EventTypeForm(CreatedByMixin, forms.ModelForm):
 
 File "/django/forms/models.py", line 261, in __new__
    fields = fields_for_model(
File "/django/forms/models.py", line 183, in fields_for_model
    formfield = f.formfield(**kwargs)
File "/django/db/models/fields/related.py", line 991, in formfield
    'queryset': self.remote_field.model._default_manager.using(using),
File "/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
File "/rh/models.py", line 27, in get_queryset
    return super().get_queryset().none()
File "/easy_tenants/models.py", line 15, in get_queryset
    current_tenant = get_current_tenant()
File "/easy_tenants/utils.py", line 19, in get_current_tenant
    if state["enabled"] and state["tenant"] is None:
TypeError: 'NoneType' object is not subscriptable
```

This was found using Django ModelForm, the related fields get_queryset will be called at server start (runserver) so before the state is set. This also causes the issue, if fixed, that the get_queryset will always return no tenant because Django won't re-call the get_queryset function after this initial run. So currently I manually reset queryset at __init__ in each form and use the following manager (so that TenantError is not thrown)

```
class CustomTenantManager(TenantManager):
    def get_queryset(self):
        state = get_state()

        if not state.get("enabled", True):
            return super().get_queryset()

        if not state.get('tenant', None):
            return super(models.Manager, self).get_queryset().none()

        current_tenant = get_current_tenant()
        return super().get_queryset().filter(tenant=current_tenant)
```

