### PR TITLE
admin creating model object, tenant_id is null

### DIFF
--- a/easy_tenants/models.py
+++ b/easy_tenants/models.py
@@ -51,7 +51,8 @@ class TenantAwareAbstract(models.Model):
 
     def save(self, *args, **kwargs):
         """Set tenant field on save"""
-        setattr(self, field_name, get_current_tenant())
+        if getattr(self, field_name) is None:
+            setattr(self, field_name, get_current_tenant())
 
         super().save(*args, **kwargs)
 

--- a/easy_tenants/models.py
+++ b/easy_tenants/models.py
@@ -51,8 +51,8 @@ class TenantAwareAbstract(models.Model):
 
     def save(self, *args, **kwargs):
         """Set tenant field on save"""
-        if getattr(self, field_name) is None:
-            setattr(self, field_name, get_current_tenant())
+
+        setattr(self, field_name, get_current_tenant())
 
         super().save(*args, **kwargs)
 


### PR DESCRIPTION
If an admin user is creating a model object tenant_id cannot be null. With get_current_tenant() an admin user will have no tenant if middleware of example is used (if url starts with /admin/, tenant filter is disabled in admin)